### PR TITLE
Update JACL from Garglk

### DIFF
--- a/jacl/glk_startup.c
+++ b/jacl/glk_startup.c
@@ -31,7 +31,7 @@ extern short int	release;
 glkunix_startup_t *arguments;
 
 /* THE STREAM FOR OPENING UP THE ARCHIVE CONTAINING GRAPHICS AND SOUND */
-strid_t				blorb_stream;
+extern strid_t				blorb_stream;
 
 /* PROTOTYPE FOR NEEDED UTILITY FUNCTION */
 void create_paths();

--- a/jacl/parser.c
+++ b/jacl/parser.c
@@ -62,7 +62,7 @@ char							*from_word;
 
 int								object_expected = FALSE;
 
-char							default_function[84];
+extern char							default_function[84];
 char							object_name[84];
 
 char				            base_function[84];


### PR DESCRIPTION
This update is short.

As I only compile the terps with remglk, I've found that jacl will fail because it will not find [glk.h](https://github.com/cspiegel/terps/blob/master/jacl/jacl.c#L24) because it looks into glkterm/
