### PR TITLE
From ScummVM: Fix array overrun - 44a19cc

### DIFF
--- a/level9/level9.c
+++ b/level9/level9.c
@@ -1504,7 +1504,7 @@ L9BOOL intinitialise(char*filename,char*picname)
 			error("\rWhat appears to be V1 game data was found, but the game was not recognised.\rEither this is an unknown V1 game file or, more likely, it is corrupted.\r");
 			return FALSE;
 		}
-		for (i=0;i<6;i++)
+		for (i=0;i<5;i++)
 		{
 			int off=L9V1Games[L9V1Game].L9Ptrs[i];
 			if (off<0)


### PR DESCRIPTION
I have added [this modfication](https://github.com/scummvm/scummvm/commit/44a19cc57024a2e9e0cd711919d824508d4dc943#diff-61c6e073725f8ddfc4fecbdebbd5bae06482c51bea0fce4b802325f6f66bf2ad)

Honestly I never found with an error detecting v1 games. 
Do you reckon this is correct?